### PR TITLE
What would a common exporter interface be like?

### DIFF
--- a/sdk/common/src/main/java/io/opentelemetry/sdk/common/OtelExporter.java
+++ b/sdk/common/src/main/java/io/opentelemetry/sdk/common/OtelExporter.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.sdk.common;
+
+import java.util.Collection;
+
+public interface OtelExporter<T> {
+
+  CompletableResultCode export(Collection<T> data);
+
+  CompletableResultCode flush();
+
+  CompletableResultCode shutdown();
+}

--- a/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordExporter.java
+++ b/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/export/LogRecordExporter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.logs.export;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.OtelExporter;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
@@ -22,7 +23,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @since 1.27.0
  */
-public interface LogRecordExporter extends Closeable {
+public interface LogRecordExporter extends OtelExporter<LogRecordData>, Closeable {
 
   /**
    * Returns a {@link LogRecordExporter} which delegates all exports to the {@code exporters} in
@@ -62,6 +63,7 @@ public interface LogRecordExporter extends Closeable {
    * @param logs the collection of {@link LogRecordData} to be exported
    * @return the result of the export, which is often an asynchronous operation
    */
+  @Override
   CompletableResultCode export(Collection<LogRecordData> logs);
 
   /**
@@ -69,6 +71,7 @@ public interface LogRecordExporter extends Closeable {
    *
    * @return the result of the flush, which is often an asynchronous operation
    */
+  @Override
   CompletableResultCode flush();
 
   /**
@@ -78,6 +81,7 @@ public interface LogRecordExporter extends Closeable {
    *
    * @return a {@link CompletableResultCode} which is completed when shutdown completes
    */
+  @Override
   CompletableResultCode shutdown();
 
   /** Closes this {@link LogRecordExporter}, releasing any resources. */

--- a/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
+++ b/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/export/MetricExporter.java
@@ -8,6 +8,7 @@ package io.opentelemetry.sdk.metrics.export;
 import static io.opentelemetry.sdk.common.export.MemoryMode.IMMUTABLE_DATA;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.OtelExporter;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -28,7 +29,10 @@ import java.util.concurrent.TimeUnit;
  * @since 1.14.0
  */
 public interface MetricExporter
-    extends AggregationTemporalitySelector, DefaultAggregationSelector, Closeable {
+    extends OtelExporter<MetricData>,
+        AggregationTemporalitySelector,
+        DefaultAggregationSelector,
+        Closeable {
 
   /**
    * Return the default aggregation for the {@link InstrumentType}.
@@ -58,6 +62,7 @@ public interface MetricExporter
    * @param metrics the metrics to export.
    * @return the result of the export, which is often an asynchronous operation.
    */
+  @Override
   CompletableResultCode export(Collection<MetricData> metrics);
 
   /**
@@ -65,6 +70,7 @@ public interface MetricExporter
    *
    * @return the result of the flush, which is often an asynchronous operation.
    */
+  @Override
   CompletableResultCode flush();
 
   /**
@@ -74,6 +80,7 @@ public interface MetricExporter
    *
    * @return a {@link CompletableResultCode} which is completed when shutdown completes.
    */
+  @Override
   CompletableResultCode shutdown();
 
   /** Closes this {@link MetricExporter}, releasing any resources. */

--- a/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
+++ b/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/SpanExporter.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.sdk.trace.export;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.OtelExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -20,10 +21,10 @@ import java.util.concurrent.TimeUnit;
  * An interface that allows different tracing services to export recorded data for sampled spans in
  * their own format.
  *
- * <p>To export data this MUST be register to the {@code TracerSdk} using a {@link
+ * <p>To export data this MUST be registered to the {@code TracerSdk} using a {@link
  * SimpleSpanProcessor} or a {@code BatchSampledSpansProcessor}.
  */
-public interface SpanExporter extends Closeable {
+public interface SpanExporter extends OtelExporter<SpanData>, Closeable {
 
   /**
    * Returns a {@link SpanExporter} which delegates all exports to the {@code exporters} in order.
@@ -63,6 +64,7 @@ public interface SpanExporter extends Closeable {
    * @param spans the collection of sampled Spans to be exported.
    * @return the result of the export, which is often an asynchronous operation.
    */
+  @Override
   CompletableResultCode export(Collection<SpanData> spans);
 
   /**
@@ -73,6 +75,7 @@ public interface SpanExporter extends Closeable {
    *
    * @return the result of the flush, which is often an asynchronous operation.
    */
+  @Override
   CompletableResultCode flush();
 
   /**
@@ -81,6 +84,7 @@ public interface SpanExporter extends Closeable {
    *
    * @return a {@link CompletableResultCode} which is completed when shutdown completes.
    */
+  @Override
   CompletableResultCode shutdown();
 
   /** Closes this {@link SpanExporter}, releasing any resources. */


### PR DESCRIPTION
Is it feasible? I can't get jApiCmp to pass with this...but we can talk about it maybe?

There are a few places that could probably benefit from this:

1. This android PR dealing with deferring export: https://github.com/open-telemetry/opentelemetry-android/pull/709
2. Disk-buffering in contrib? https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/disk-buffering
3. What else?